### PR TITLE
Ability to pass an arguments hash to the materialize class method

### DIFF
--- a/lib/faceted/model.rb
+++ b/lib/faceted/model.rb
@@ -44,9 +44,9 @@ module Faceted
         @fields ||= [:id, :excludes]
       end
 
-      def materialize(objects=[])
+      def materialize(objects=[], args={})
         objects.compact.inject([]) do |a, object|
-          interface = self.new
+          interface = self.new(args)
           interface.send(:object=, object)
           interface.send(:initialize_with_object)
           a << interface


### PR DESCRIPTION
Firstly, thanks for your great gem!

We're using Faceted in a project that doesn't use a classical ORM that supports methods such as 'where', etc. and thus we call the materialize method straight from our controller, as in:

```
Musician.materialize(results)
```

and want to be also be able to pass in an 'excludes' hash, as you currently allow when simply creating a new presenter. So, we'd like to be able to do something like this:

```
Musician.materialize(results, :excludes => [:id])
```

This pull request allows the passing of such an argument hash.

Thanks!
